### PR TITLE
[#4] - Install the `django-cors-headers` package

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ factory-boy = "*"
 djangorestframework = "*"
 markdown = "*"
 django-filter = "*"
+django-cors-headers = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "af065b933cf7a3c0a540b00e128776842ac800cdb1f3d6c8b2d318b1c1438037"
+            "sha256": "ea107e9a99293d39399b2c1082b9a8d34345372cced6bb5b5ba005e06eb429ab"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             ],
             "index": "pypi",
             "version": "==2.2"
+        },
+        "django-cors-headers": {
+            "hashes": [
+                "sha256:5b80bf0f8d7fc6e2bcb4f40781d5ff3661961bbf1982e52daec77241dea3b890",
+                "sha256:ebf3e2cf25aa6993b959a8e6a87828ebb3c8fe5bc3ec4a2d6e65f3b8d9b4212c"
+            ],
+            "index": "pypi",
+            "version": "==3.0.2"
         },
         "django-extensions": {
             "hashes": [

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
 
 INSTALLED_APPS += [
     'rest_framework',
+    'corsheaders',
 ]
 
 
@@ -51,6 +52,7 @@ INSTALLED_APPS += [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -149,3 +151,8 @@ AUTHENTICATION_BACKENDS = [
 # Custom Auth User Model
 
 AUTH_USER_MODEL = 'accounts.CustomUser'
+
+
+# Cors Headers
+
+CORS_ORIGIN_ALLOW_ALL = True


### PR DESCRIPTION
Closes #4