### PR TITLE
[#7] - Fix the typo in the `User` model `id` field type

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 
 class CustomUser(AbstractUser):
-    id = models.UUIDFied(primary_key=True, editable=False, default=uuid4)
+    id = models.UUIDField(primary_key=True, editable=False, default=uuid4)
 
 
 class Profile(models.Model):


### PR DESCRIPTION
Closes #7 